### PR TITLE
Script to build wheels in manylinux docker image

### DIFF
--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e -x
+
+# Install a system package required by our library
+yum install -y libtdb-devel
+
+cd /io/
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    if [[ "$PYBIN" == *"cp26"* ]]; then
+        continue
+    fi
+    PATH=/opt/python/cp27-cp27m/bin/:$PATH "${PYBIN}/python" /io/setup.py bdist_wheel --dist-dir /io/wheelhouse/
+done
+
+# Bundle external shared libraries into the wheels
+for whl in /io/wheelhouse/*.whl; do
+    auditwheel repair "$whl" -w /io/wheelhouse/
+done


### PR DESCRIPTION
cf https://github.com/pypa/python-manylinux-demo/blob/master/.travis.yml on how to use this on Travis.

Basically, you need to run `sudo docker run --rm -v $(pwd):/io quay.io/pypa/manylinux1_x86_64:latest bash /io/build-manylinux-wheels.sh`, and wheels will be created in a `wheelhouse` folder for py27, py34, py35, py36.

I guess the best would be to be able to publish releases and wheels to https://pypi.python.org/pypi/tdb, but an alternative would be to rename this package to something like tdb-manypython or python-tdb.

Anyway, your project helped me to keep using py35/py36 and not go back to http://packages.ubuntu.com/xenial/python-tdb built only for py27.

Thanks !